### PR TITLE
Start server with bundle script and support webpack watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Thumbs.db
 #################
 bower_components/*
 node_modules/*
+
+# build
+public/assets/build/*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server"
+    "start": "node server/app.js",
+    "build": "webpack",
+    "watch": "webpack --progress --colors --watch",
+    "dev": "webpack-dev-server --progress --colors"
   },
   "author": "Kaijie Zhan <ceres0503@icloud.com>",
   "license": "MIT",

--- a/public/index.html
+++ b/public/index.html
@@ -56,7 +56,7 @@
 
 
   <!-- vendor -->
-  <script src="http://localhost:8080/public/assets/build/bundle.js"></script>
+  <script src="assets/build/bundle.js"></script>
 
 </body>
 

--- a/server/expressConfig.js
+++ b/server/expressConfig.js
@@ -6,13 +6,13 @@ module.exports = function(app, express) {
   // Serve static assets from the app folder. This enables things like javascript
   // and stylesheets to be loaded as expected. You would normally use something like
   // nginx for this, but this makes for a simpler demo app to just let express do it.
-  
-  //app.use("/", express.static("public/"));
+
+  app.use("/", express.static("public/"));
   //app.use('/vendor/bootstrap', express.static(__dirname + '/../node_modules/bootstrap/dist/'));
   //app.use('/vendor/jquery', express.static(__dirname + '/../node_modules/jquery/dist/'));
 
   // Set the view directory, this enables us to use the .render method inside routes
-  //app.set('views', __dirname + '/../app/views');
+  app.set('views', __dirname + '/../public');
 
   // parse application/x-www-form-urlencoded
   app.use(bodyParser.urlencoded({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'public/assets/build'),
     filename: 'bundle.js',
-    publicPath: 'public/assets/build/'
+    publicPath: '/assets/build/'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Modify something below:
- add some package script, such as build, watch, start
- to use relative public path instead of full path
- fix public path
